### PR TITLE
Only try to update workflows with a package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,8 +47,8 @@ const checkAndUpdate = async filePath => {
 
 		const workflowDir = path.join(alfredPreferences.path, 'workflows');
 
-		// Retrieve all the symlinks from the workflows directory
-		const filePaths = await utils.findSymlinks(workflowDir);
+		// Retrieve all the npm symlinks from the workflows directory
+		const filePaths = await utils.findNpmSymlinks(workflowDir);
 
 		// Iterate over all the workflows, check if they are outdated and update them
 		const promises = filePaths.map(filePath => checkAndUpdate(filePath));

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,7 +5,7 @@ const pify = require('pify');
 
 const fsP = pify(fs);
 
-exports.findSymlinks = async dir => {
+exports.findNpmSymlinks = async dir => {
 	const files = await fsP.readdir(dir);
 
 	const promises = files.map(async file => {
@@ -14,7 +14,10 @@ exports.findSymlinks = async dir => {
 		const stats = await fsP.lstat(filePath);
 
 		if (stats.isSymbolicLink()) {
-			return filePath;
+			const packagePath = path.resolve(filePath, 'package.json');
+			if (fs.existsSync(packagePath)) {
+				return filePath;
+			}
 		}
 	});
 


### PR DESCRIPTION
Adding this check because I use symlinks to link to workflows I'm developing (which are not Node-based). Without this check I get errors similar that reported in #6:

> ENOENT: no such file or directory, open '~/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/*my- workflow*/package.json'

(However, I still get the "Unable to start Alfred 4" dialog so the code to kill the current alfred doesn't seem to work for me)